### PR TITLE
Parse strings to float64 for jsonpath collector

### DIFF
--- a/pkg/collector/json_path_collector.go
+++ b/pkg/collector/json_path_collector.go
@@ -83,6 +83,8 @@ func (g *JSONPathMetricsGetter) GetMetric(pod *v1.Pod) (float64, error) {
 		return float64(res), nil
 	case float64:
 		return res, nil
+	case string:
+		return strconv.ParseFloat(res, 64)
 	default:
 		return 0, fmt.Errorf("unsupported type %T", res)
 	}


### PR DESCRIPTION
# One-line summary

> Parse strings to float64 for jsonpath collector

## Description
If the custom metric endpoint sends values as strings, we should at least try to parse them. If it fails to parse then the existing behavior will remain, although the returned error will be about the parse failure

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix (non-breaking change which fixes an issue)

## Tasks
_List of tasks you will do to complete the PR_


## Review
Documentation states
> It's expected that the metric you query
returns something that can be turned into a `float64`

If it's a string it could still be (possibly) turned into a `float64`, so unsure if the documentation needs to be updated.

## Deployment Notes
None
