### PR TITLE
Add podAnnotation capability to chart

### DIFF
--- a/deploy/charts/kube-metrics-adapter/README.md
+++ b/deploy/charts/kube-metrics-adapter/README.md
@@ -49,6 +49,7 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 | `rbac.create`                   | If true, create & use RBAC resources                                            | `true`                                      |
 | `resources`                     | CPU/Memory resource requests/limits                                             | `{}`                                        |                                                                                                        
 | `service.annotations`           | Annotations to add to the service                                               | `{}`                                        |
+| `adapter.podAnnotations`        | Annotations to add to the pods                                                  | `{}`                                        |
 | `service.port`                  | Service port to expose                                                          | `443`                                       |
 | `service.internalPort`          | Service internal port                                                           | `6443`                                      |
 | `service.type`                  | Type of service to create                                                       | `ClusterIP`                                 |

--- a/deploy/charts/kube-metrics-adapter/templates/deployment.yaml
+++ b/deploy/charts/kube-metrics-adapter/templates/deployment.yaml
@@ -15,6 +15,10 @@ spec:
       release: "{{ .Release.Name }}"
   template:
     metadata:
+    {{- if .Values.adapter.podAnnotations }}
+      annotations:
+{{ toYaml .Values.adapter.podAnnotations | indent 8 }}
+    {{- end }}
       labels:
         app: {{ template "kube-metrics-adapter.name" . }}
         chart: {{ template "kube-metrics-adapter.chart" . }}

--- a/deploy/charts/kube-metrics-adapter/values.yaml
+++ b/deploy/charts/kube-metrics-adapter/values.yaml
@@ -36,6 +36,9 @@ resources:
     cpu: 100m
     memory: 100Mi
 
+adapter:
+  podAnnotations: {}
+
 service:
   annotations: {}
   port: 443


### PR DESCRIPTION
# One-line summary

> Issue : #4 

## Description
Add capability to add podAnnotations to kube-metrics-adapter deployments.

## Types of Changes
- New feature (non-breaking change which adds functionality)
