### PR TITLE
chart: add enableHostNetwork param

### DIFF
--- a/deploy/charts/kube-metrics-adapter/Chart.yaml
+++ b/deploy/charts/kube-metrics-adapter/Chart.yaml
@@ -1,5 +1,5 @@
 name: kube-metrics-adapter
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.1.1
 description: A Helm chart for kube-metrics-adapter
 home: https://github.com/zalando-incubator/kube-metrics-adapter

--- a/deploy/charts/kube-metrics-adapter/README.md
+++ b/deploy/charts/kube-metrics-adapter/README.md
@@ -50,6 +50,7 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 | `resources`                     | CPU/Memory resource requests/limits                                             | `{}`                                        |                                                                                                        
 | `service.annotations`           | Annotations to add to the service                                               | `{}`                                        |
 | `adapter.podAnnotations`        | Annotations to add to the pods                                                  | `{}`                                        |
+| `enableHostNetwork`             | Enable host network for adapter                                                 | `true`                                      |
 | `service.port`                  | Service port to expose                                                          | `443`                                       |
 | `service.internalPort`          | Service internal port                                                           | `6443`                                      |
 | `service.type`                  | Type of service to create                                                       | `ClusterIP`                                 |

--- a/deploy/charts/kube-metrics-adapter/README.md
+++ b/deploy/charts/kube-metrics-adapter/README.md
@@ -50,7 +50,7 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 | `resources`                     | CPU/Memory resource requests/limits                                             | `{}`                                        |                                                                                                        
 | `service.annotations`           | Annotations to add to the service                                               | `{}`                                        |
 | `adapter.podAnnotations`        | Annotations to add to the pods                                                  | `{}`                                        |
-| `enableHostNetwork`             | Enable host network for adapter                                                 | `true`                                      |
+| `enableHostNetwork`             | Enable host network for adapter                                                 | `false`                                      |
 | `service.port`                  | Service port to expose                                                          | `443`                                       |
 | `service.internalPort`          | Service internal port                                                           | `6443`                                      |
 | `service.type`                  | Type of service to create                                                       | `ClusterIP`                                 |

--- a/deploy/charts/kube-metrics-adapter/templates/deployment.yaml
+++ b/deploy/charts/kube-metrics-adapter/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
+      hostNetwork: {{ .Values.enableHostNetwork }}
       serviceAccountName: {{ template "kube-metrics-adapter.fullname" . }}
       securityContext:
         runAsNonRoot: true

--- a/deploy/charts/kube-metrics-adapter/values.yaml
+++ b/deploy/charts/kube-metrics-adapter/values.yaml
@@ -9,6 +9,8 @@ logLevel: 1
 enableCustomMetricsApi: false
 enableExternalMetricsApi: true
 
+enableHostNetwork: true
+
 # Url to access prometheus
 prometheus:
   url:

--- a/deploy/charts/kube-metrics-adapter/values.yaml
+++ b/deploy/charts/kube-metrics-adapter/values.yaml
@@ -9,7 +9,7 @@ logLevel: 1
 enableCustomMetricsApi: false
 enableExternalMetricsApi: true
 
-enableHostNetwork: true
+enableHostNetwork: false
 
 # Url to access prometheus
 prometheus:


### PR DESCRIPTION
Add enableHostNetwork param to enable the adapter working with Weave Net CNI Plugin. see: https://github.com/banzaicloud/banzai-charts/issues/1060