### PR TITLE
Adding missing apiVersion to Chart.yaml

### DIFF
--- a/deploy/charts/kube-metrics-adapter/Chart.yaml
+++ b/deploy/charts/kube-metrics-adapter/Chart.yaml
@@ -1,5 +1,6 @@
+apiVersion: v1
 name: kube-metrics-adapter
-version: 0.1.3
+version: 0.1.4
 appVersion: 0.1.1
 description: A Helm chart for kube-metrics-adapter
 home: https://github.com/zalando-incubator/kube-metrics-adapter


### PR DESCRIPTION
This will add the required field `apiVersion` to `Chart.yaml`. Currently some Helm client implementation (notably Terraform helm provider) will fail if Chart.yaml is missing this field as it is a [required field.](https://helm.sh/docs/topics/charts/#the-apiversion-field)

`apiVersion` is kept at `v1` to remain usable with Helm 2 but I have only tested this with Helm 3 (Terraform).