### PR TITLE
Set enableCustomMetricsApi to `true`

### DIFF
--- a/deploy/charts/kube-metrics-adapter/values.yaml
+++ b/deploy/charts/kube-metrics-adapter/values.yaml
@@ -6,7 +6,7 @@ image:
 
 logLevel: 1
 
-enableCustomMetricsApi: false
+enableCustomMetricsApi: true
 enableExternalMetricsApi: true
 
 enableHostNetwork: false


### PR DESCRIPTION
# One-line summary

Set enableCustomMetricsApi to `true` to match the documented default value for this setting.

## Description
The readme states enableCustomMetricsApi is set to `true` by default while it is actually set to false. This should be fixed.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- Bug fix (non-breaking change which fixes an issue)
- Configuration change
