### PR TITLE
Update rbac.yaml

### DIFF
--- a/deploy/charts/kube-metrics-adapter/templates/rbac.yaml
+++ b/deploy/charts/kube-metrics-adapter/templates/rbac.yaml
@@ -63,6 +63,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create


### PR DESCRIPTION
added below for the collector.

```
- apiGroups:
  - ""
  resources:
  - configmaps
  verbs:
  - list
  - watch
```

# One-line summary

There was issue with configmap resource for latest image from Zalando(image.tag=v0.1.5) refer defect and resolution here.
`https://github.com/zalando-incubator/kube-metrics-adapter/issues/142`


## Description

Added correct level of access to config maps for metrics collector.

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_


- Bug fix (non-breaking change which fixes an issue)


