### PR TITLE
Add InfluxDB support

### DIFF
--- a/deploy/charts/kube-metrics-adapter/README.md
+++ b/deploy/charts/kube-metrics-adapter/README.md
@@ -18,7 +18,7 @@ This command deploys the kube-metrics-adapter with the default configuration. Th
 
 ## Using the Chart
 
-[kube-metrics-adapter](https://github.com/banzaicloud/kube-metrics-adapter) can be configure to use several different collectors. Currently this chart supports only configuration of Prometheus collector. Ensure the `prometheus.url` and `prometheus.port` are configured with the correct Prometheus service endpoint. To configure your Horizontal Pod Autoscaler to use the custom metric, see the custom metrics section of the [HPA walkthrough](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics).
+[kube-metrics-adapter](https://github.com/banzaicloud/kube-metrics-adapter) can be configure to use several different collectors. Currently this chart supports only configuration of Prometheus and InfluxDB collectors. Ensure the `prometheus.url` and `prometheus.port` are configured with the correct Prometheus service endpoint. To configure your Horizontal Pod Autoscaler to use the custom metric, see the custom metrics section of the [HPA walkthrough](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics).
 
 ## Uninstalling the Chart
 
@@ -47,7 +47,7 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 | `enableExternalMetricsApi`                  | Enable External Metrics APIService                                                 | `true`                                        |
 | `prometheus.url`                | Url of where we can find the Prometheus service                                 | ``             |
 | `rbac.create`                   | If true, create & use RBAC resources                                            | `true`                                      |
-| `resources`                     | CPU/Memory resource requests/limits                                             | `{}`                                        |                                                                                                        
+| `resources`                     | CPU/Memory resource requests/limits                                             | `{}`                                        |
 | `service.annotations`           | Annotations to add to the service                                               | `{}`                                        |
 | `adapter.podAnnotations`        | Annotations to add to the pods                                                  | `{}`                                        |
 | `enableHostNetwork`             | Enable host network for adapter                                                 | `false`                                      |
@@ -66,6 +66,10 @@ The following table lists the configurable parameters of the Prometheus Adapter 
 | `aws.region`                    | Comma separated list of AWS regions (ignored if aws.enable=false)               | `us-west-2`                                 |
 | `tolerations`                   | List of node taints to tolerate                                                 | `[]`                                        |
 | `pspEnabled`                    | enabel PSP resources                                                            | false                                       |
+| `influxdb.enabled`              | enable InfluxDB                                                                 | false                                       |
+| `influxdb.url                   | the URL of the InfluxDB server                                                  | ``                                          |
+| `influxdb.token`                | the Token used to access InfluxDB                                               | ``                                          |
+| `influxdb.org`                  | the organization used when accessing InfluxDB                                   | ``                                          |
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console

--- a/deploy/charts/kube-metrics-adapter/templates/deployment.yaml
+++ b/deploy/charts/kube-metrics-adapter/templates/deployment.yaml
@@ -44,6 +44,11 @@ spec:
         {{- if .Values.prometheus.url }}
         - --prometheus-server={{ .Values.prometheus.url }}
         {{- end}}
+        {{- if .Values.influxdb.enable }}
+        - --influxdb-address={{ .Values.influxdb.url }}
+        - --influxdb-token={{ .Values.influxdb.token }}
+        - --influxdb-org={{ .Values.influxdb.org }}
+        {{- end }}
         {{- if .Values.tls.enable }}
         - --tls-cert-file=/var/run/serving-cert/tls.crt
         - --tls-private-key-file=/var/run/serving-cert/tls.key

--- a/deploy/charts/kube-metrics-adapter/values.yaml
+++ b/deploy/charts/kube-metrics-adapter/values.yaml
@@ -70,3 +70,12 @@ aws:
   enable: false
   # comma separated list of AWS regions where your SQS queues are deployed
   region: us-west-2
+
+influxdb:
+  enable: false
+  # The URL for InfluxDB, e.g. http://localhost:9999
+  url:
+  # The token for InfluxDB access
+  token:
+  # Organization ID for InfluxDB 2.x server to query
+  org:


### PR DESCRIPTION
# One-line summary
Adds support for InfluxDB
> Issue : #19 

## Description
This adds the ability to configure the InfluxDB collector using the relevant command-line flags on the adapter pod, in much the same way that configuring the Prometheus adapter is done.

## Types of Changes
- New feature (non-breaking change which adds functionality)
- Documentation / non-code

## Tasks
- [x] Add InfluxDB support to templates
- [x] Add required default values
- [x] Add required information to README


## Deployment Notes
`influxdb.enabled` defaults to `false`, so the default behavior of the chart remains unchanged.
