### PR TITLE
Add annotations field for the ServiceAccount

### DIFF
--- a/deploy/charts/kube-metrics-adapter/templates/service-account.yaml
+++ b/deploy/charts/kube-metrics-adapter/templates/service-account.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
+{{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+{{- end }}
 metadata:
   labels:
     app: {{ template "kube-metrics-adapter.name" . }}

--- a/deploy/charts/kube-metrics-adapter/values.yaml
+++ b/deploy/charts/kube-metrics-adapter/values.yaml
@@ -29,6 +29,8 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+  # Annotations to map to the Service Account
+  annotations: {}
 
 resources:
   limits:


### PR DESCRIPTION

# One-line summary

> Add [Annotation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) field in ServiceAccount template file and `values.yaml`.

## Description

This PR will add the annotation fields to the ServiceAccount resource. The field is really handy when mapping an AWS IAM Role to the ServiceAccount. Adding this field would avoid  giving node(s) and other applications access to the SQS cloud resources (in AWS).

This new field can be used in the following way:
```
$ cat values.yaml 
[...]
serviceAccount:
  create: true
  name: kube-metrics-adapater-sa
  annotations: 
    eks.amazonaws.com/role-arn: arn:aws:iam::1234567890:role/iam-role-kube-metrics-adapter
[...]
```

In this case the IAM AWS Role `iam-role-kube-metrics-adapter` will only have attached only Policy rules that kube-metrics-adapter needs to access.

E.g.:

```
PolicyDocument:
  Statement:
    - Action: 'sqs:GetQueueUrl'
      Effect: Allow
      Resource: 'arn:aws:sqs:eu-west-2:1234567890:queue-1'
    - Action: 'sqs:GetQueueAttributes'
      Effect: Allow
      Resource: 'arn:aws:sqs:eu-west-2:1234567890:queue-1'
    - Action: 'sqs:ListQueueTags'
      Effect: Allow
      Resource: 'arn:aws:sqs:eu-west-2:1234567890:queue-1'
    - Action: 'sqs:ListQueues'
      Effect: Allow
      Resource: '*'
  Version: 2012-10-17
```


## Types of Changes

- New feature (non-breaking change which adds functionality)
- Configuration change
- Refactor/improvements


## Review

- [ ] Tests
- [ ] Documentation
- [ ] CHANGELOG


Let me know if I need to change/add/adapt anything! Thanks for your review!

Cheers,
FP

Signed-off-by: Francesco Piva <francesco.piva@zf.com>
